### PR TITLE
Update BLERemoteService.cpp

### DIFF
--- a/src/BLERemoteService.cpp
+++ b/src/BLERemoteService.cpp
@@ -165,7 +165,9 @@ BLERemoteCharacteristic* BLERemoteService::getCharacteristic(BLEUUID uuid) {
  * @return N/A
  */
 void BLERemoteService::retrieveCharacteristics() {
-	ESP_LOGD(LOG_TAG, ">> getCharacteristics() for service: %s", getUUID().toString().c_str());
+    esp_gatt_status_t status;
+    try{	
+	ESP_LOGD(LOG_TAG, ">> retrieveCharacteristics() for service: %s", getUUID().toString().c_str());
 
 	removeCharacteristics(); // Forget any previous characteristics.
 
@@ -209,11 +211,13 @@ void BLERemoteService::retrieveCharacteristics() {
 		m_characteristicMap.insert(std::pair<std::string, BLERemoteCharacteristic*>(pNewRemoteCharacteristic->getUUID().toString(), pNewRemoteCharacteristic));
 		m_characteristicMapByHandle.insert(std::pair<uint16_t, BLERemoteCharacteristic*>(result.char_handle, pNewRemoteCharacteristic));
 		offset++;   // Increment our count of number of descriptors found.
+		m_haveCharacteristics = true; // Remember that we have received the characteristics.
 	} // Loop forever (until we break inside the loop).
-
-	m_haveCharacteristics = true; // Remember that we have received the characteristics.
-	ESP_LOGD(LOG_TAG, "<< getCharacteristics()");
-} // getCharacteristics
+    }catch(const std::exception&){
+	ESP_LOGE(LOG_TAG, "Catched exception inside retrieveCharacteristics!!!");
+    }
+    ESP_LOGD(LOG_TAG, "<< retrieveCharacteristics()");
+} // retrieveCharacteristics
 
 
 /**


### PR DESCRIPTION
If exceptions are not catched inside BLERemoteService::retrieveCharacteristics(), a core dump may occur ocassionally:

`[D][BLERemoteService.cpp:168] retrieveCharacteristics(): >> getCharacteristics() for service: 0000181d-0000-1000-8000-00805f9b34fb
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
Core 1 register dump:
PC      : 0x4008bb20  PS      : 0x00060730  A0      : 0x800d688d  A1      : 0x3ffca020
A2      : 0x00351221  A3      : 0x00000000  A4      : 0x00000019  A5      : 0x00000023
A6      : 0x3ffca092  A7      : 0x3ffca07c  A8      : 0x00351221  A9      : 0x3ffc9fe0
A10     : 0x00000000  A11     : 0x00000000  A12     : 0x00000001  A13     : 0x00000000
A14     : 0x3ffca07c  A15     : 0x00000000  SAR     : 0x00000018  EXCCAUSE: 0x0000001c
EXCVADDR: 0x00351221  LBEG    : 0x4000c349  LEND    : 0x4000c36b  LCOUNT  : 0xffffffff

Backtrace: 0x4008bb20:0x3ffca020 0x400d688a:0x3ffca040 0x400d6c2e:0x3ffca100 0x400d1ceb:0x3ffca160 0x400d1e3b:0x3ffca1b0 0x400d9a15:0x3ffca210 0x4009257d:0x3ffca230

Rebooting...
ets Jun  8 2016 00:22:57`
